### PR TITLE
Subpixel fixes

### DIFF
--- a/src/components/MetaballTracer.js
+++ b/src/components/MetaballTracer.js
@@ -140,7 +140,7 @@ const enhance = compose(
     mode: 'color',
   }),
   withState('canvasContext', 'setCanvasContext'),
-  withState('circles', 'setCircles'),
+  withState('circleGroups', 'setCircleGroups'),
   withState('SVGImageSource', 'setSVGImageSource'),
   withStateHandlers({}, {
     setState: () => (newState) => (newState),
@@ -159,7 +159,7 @@ const enhance = compose(
         scale,
         scaledHeight,
         scaledWidth,
-        setCircles,
+        setCircleGroups,
         setSVGImageSource,
         width,
       } = {...props, ...nextState};
@@ -193,8 +193,14 @@ const enhance = compose(
       }
 
       // map colorScale to fill by comparing it to the min/max values and thresholds
+      const circleGroups = {};
       each(circles, (circle) => {
         analyzer.paintShape(circle);
+        const circleGroup = circleGroups[circle.fill.key] = circleGroups[circle.fill.key] || {
+          paint: circle.fill,
+          circles: [],
+        };
+        circleGroup.circles.push(circle);
       });
 
       // run through grid and create connections between same-color dots
@@ -212,10 +218,10 @@ const enhance = compose(
         }
       }
 
-      const metaballsProps = {width, height, circles, scale};
+      const metaballsProps = {width, height, circleGroups, scale};
       const SVGImageSource = getSVGImageSourceFromComponent(<Metaballs {...metaballsProps} />);
 
-      setCircles(circles);
+      setCircleGroups(circleGroups);
       setSVGImageSource(SVGImageSource);
     },
   }),

--- a/src/components/MetaballTracer.js
+++ b/src/components/MetaballTracer.js
@@ -75,13 +75,13 @@ class ColorAnalyzer {
   paintShape(shape) {
     const relativeColorScale = (shape.colorScale - this.colorScaleMin) / (this.colorScaleMax - this.colorScaleMin);
 
-    // TODO: store relativeColorScale and move the fill logic out to the render method
+    // TODO: store relativeColorScale and move the color logic out to the render method
     if (relativeColorScale < this.lowThreshold) {
-      shape.fill = COLOR.BLUE;
+      shape.color = COLOR.BLUE;
     } else if (relativeColorScale > this.highThreshold) {
-      shape.fill = COLOR.RED;
+      shape.color = COLOR.RED;
     } else {
-      shape.fill = COLOR.PURPLE;
+      shape.color = COLOR.PURPLE;
     }
   }
 }
@@ -117,13 +117,13 @@ class MonochromeAnalyzer {
   paintShape(shape) {
     const relativeColorScale = (shape.colorScale - this.colorScaleMin) / (this.colorScaleMax - this.colorScaleMin);
 
-    // TODO: store relativeColorScale and move the fill logic out to the render method
+    // TODO: store relativeColorScale and move the color logic out to the render method
     if (relativeColorScale < this.lowThreshold) {
-      shape.fill = COLOR.GRAY;
+      shape.color = COLOR.GRAY;
     } else if (relativeColorScale > this.highThreshold) {
-      shape.fill = COLOR.WHITE;
+      shape.color = COLOR.WHITE;
     } else {
-      shape.fill = COLOR.LIGHT_GRAY;
+      shape.color = COLOR.LIGHT_GRAY;
     }
   }
 }
@@ -192,12 +192,12 @@ const enhance = compose(
         }
       }
 
-      // map colorScale to fill by comparing it to the min/max values and thresholds
+      // map colorScale to color by comparing it to the min/max values and thresholds
       const circleGroups = {};
       each(circles, (circle) => {
         analyzer.paintShape(circle);
-        const circleGroup = circleGroups[circle.fill.key] = circleGroups[circle.fill.key] || {
-          paint: circle.fill,
+        const circleGroup = circleGroups[circle.color.key] = circleGroups[circle.color.key] || {
+          paint: circle.color,
           circles: [],
         };
         circleGroup.circles.push(circle);
@@ -209,10 +209,10 @@ const enhance = compose(
           const circle = grid[x][y];
           const circleRight = grid[x + 1][y];
           const circleDown = grid[x][y + 1];
-          if (circle.fill === circleRight.fill && random((x + 234) * (y + 345)) < connectorFrequency) {
+          if (circle.color === circleRight.color && random((x + 234) * (y + 345)) < connectorFrequency) {
             circle.hasRightConnector = true;
           }
-          if (circle.fill === circleDown.fill && random((x + 456) * (y + 567)) < connectorFrequency) {
+          if (circle.color === circleDown.color && random((x + 456) * (y + 567)) < connectorFrequency) {
             circle.hasDownConnector = true;
           }
         }

--- a/src/components/svg/Dot.js
+++ b/src/components/svg/Dot.js
@@ -1,9 +1,7 @@
 import React from 'react';
 
-const SUBPIXEL_KILLER = 1.02;
-
 const Dot = ({cx, cy, scale, ...restProps}) => (
-  <circle cx={cx / scale} cy={cy / scale} r={0.5 / 1.44 / scale * SUBPIXEL_KILLER} {...restProps} />
+  <circle cx={cx / scale} cy={cy / scale} r={0.5 / 1.44 / scale} {...restProps} />
 );
 
 export default Dot;

--- a/src/components/svg/Dot.js
+++ b/src/components/svg/Dot.js
@@ -1,7 +1,9 @@
 import React from 'react';
 
+const sin45 = Math.cos(45 * Math.PI / 180) * 2;
+
 const Dot = ({cx, cy, scale, ...restProps}) => (
-  <circle cx={cx / scale} cy={cy / scale} r={0.5 / 1.44 / scale} {...restProps} />
+  <circle cx={cx / scale} cy={cy / scale} r={0.5 / sin45 / scale} {...restProps} />
 );
 
 export default Dot;

--- a/src/components/svg/DotConnector.js
+++ b/src/components/svg/DotConnector.js
@@ -1,24 +1,58 @@
 import React from 'react';
 import { withPropsOnChange } from 'recompose';
 
+const pathDataHorizontal = [
+  'M0,0',
+  'c27.61,27.61 72.39,27.61 100,0',
+  'l0,100',
+  'c-27.61,-27.61 -72.39,-27.61 -100,0',
+  'l0,-100',
+  'z',
+].join('');
+
+const pathDataVertical = [
+  'M0,0',
+  'l100,0',
+  'c-27.61,27.61 -27.61,72.39 0,100',
+  'l-100,0',
+  'c27.61,-27.61 27.61,-72.39 0,-100',
+  'z',
+].join('');
+
 const enhance = withPropsOnChange(['direction'], ({direction}) => {
   if (direction === 'up') {
-    return {offsetX: -0.25, offsetY: -0.75};
+    return {
+      offsetX: -0.25,
+      offsetY: -0.75,
+      pathData: pathDataVertical,
+    };
   }
   if (direction === 'down') {
-    return {offsetX: -0.25, offsetY: 0.25};
+    return {
+      offsetX: -0.25,
+      offsetY: 0.25,
+      pathData: pathDataVertical,
+    };
   }
   if (direction === 'left') {
-    return {offsetX: -0.75, offsetY: -0.25};
+    return {
+      offsetX: -0.75,
+      offsetY: -0.25,
+      pathData: pathDataHorizontal,
+    };
   }
   if (direction === 'right') {
-    return {offsetX: 0.25, offsetY: -0.25};
+    return {
+      offsetX: 0.25,
+      offsetY: -0.25,
+      pathData: pathDataHorizontal,
+    };
   }
 });
 
-const DotConnector = ({cx, cy, direction, offsetX, offsetY, scale, ...restProps}) => (
+const DotConnector = ({cx, cy, direction, offsetX, offsetY, pathData, scale, ...restProps}) => (
   <path
-    d="M0,0c27.61,27.61 72.39,27.61 100,0c-27.61,27.61 -27.61,72.39 0,100c-27.61,-27.61 -72.39,-27.61 -100,0c27.61,-27.61 27.61,-72.39 0,-100z"
+    d={pathData}
     transform={`translate(${(cx + offsetX) / scale}, ${(cy + offsetY) / scale}) scale(${0.5 / 100 / scale})`}
     {...restProps}
   />

--- a/src/components/svg/Metaballs.js
+++ b/src/components/svg/Metaballs.js
@@ -4,29 +4,33 @@ import {map} from 'lodash';
 import Dot from './Dot';
 import DotConnector from './DotConnector';
 
-const Metaballs = ({width, height, circles, scale}) => (
+const Metaballs = ({width, height, circleGroups, scale}) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={`${width}px`}
     height={`${height}px`}
   >
-    {map(circles, ({cx, cy, fill, hasDownConnector, hasRightConnector}, i) => {
-      const shapeProps = {cx, cy, fill, scale};
+    {map(circleGroups, ({circles, paint}, j) => (
+      <g key={j} opacity={paint.opacity}>
+        {map(circles, ({cx, cy, fill, hasDownConnector, hasRightConnector}, i) => {
+          const shapeProps = {cx, cy, fill: fill.hex, scale};
 
-      return (
-        <React.Fragment key={i}>
-          <Dot {...shapeProps} />
+          return (
+            <React.Fragment key={i}>
+              <Dot {...shapeProps} />
 
-          {hasDownConnector && (
-            <DotConnector {...shapeProps} direction="down"/>
-          )}
+              {hasDownConnector && (
+                <DotConnector {...shapeProps} direction="down"/>
+              )}
 
-          {hasRightConnector && (
-            <DotConnector {...shapeProps} direction="right"/>
-          )}
-        </React.Fragment>
-      )
-    })}
+              {hasRightConnector && (
+                <DotConnector {...shapeProps} direction="right"/>
+              )}
+            </React.Fragment>
+          )
+        })}
+      </g>
+    ))}
   </svg>
 );
 

--- a/src/components/svg/Metaballs.js
+++ b/src/components/svg/Metaballs.js
@@ -12,8 +12,8 @@ const Metaballs = ({width, height, circleGroups, scale}) => (
   >
     {map(circleGroups, ({circles, paint}, j) => (
       <g key={j} opacity={paint.opacity}>
-        {map(circles, ({cx, cy, fill, hasDownConnector, hasRightConnector}, i) => {
-          const shapeProps = {cx, cy, fill: fill.hex, scale};
+        {map(circles, ({cx, cy, color, hasDownConnector, hasRightConnector}, i) => {
+          const shapeProps = {cx, cy, fill: color.hex, scale};
 
           return (
             <React.Fragment key={i}>

--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -1,10 +1,32 @@
+import {each} from 'lodash';
+
 const COLOR = {
-  BLUE: '#007AFF',
-  PURPLE: '#D000D6',
-  RED: '#F07',
-  WHITE: '#FFF',
-  LIGHT_GRAY: '#FFFFFF99',
-  GRAY: '#FFFFFF66',
+  BLUE: {
+    hex: '#007AFF',
+    opacity: 1,
+  },
+  PURPLE: {
+    hex: '#D000D6',
+    opacity: 1,
+  },
+  RED: {
+    hex: '#F07',
+    opacity: 1,
+  },
+  WHITE: {
+    hex: '#fff',
+    opacity: 1,
+  },
+  LIGHT_GRAY: {
+    hex: '#fff',
+    opacity: 0.5,
+  },
+  GRAY: {
+    hex: '#fff',
+    opacity: 0.25,
+  },
 };
+
+each(COLOR, (o, key) => o.key = key);
 
 export default COLOR;

--- a/src/utilities/getSVGImageSourceFromComponent.js
+++ b/src/utilities/getSVGImageSourceFromComponent.js
@@ -2,8 +2,6 @@ import {renderToString} from 'react-dom/server';
 
 const getSVGImageSourceFromComponent = (component) => {
   let metaballsSVGString = renderToString(component);
-  metaballsSVGString = metaballsSVGString.replace(/><\/[A-z]+>/g, '/>');
-  metaballsSVGString = metaballsSVGString.replace(/data-reactroot=""/g, '');
   // console.log(metaballsSVGString);
   metaballsSVGString = encodeURIComponent(metaballsSVGString);
   return `data:image/svg+xml;charset=utf-8,${metaballsSVGString}`;


### PR DESCRIPTION
This pull request resolves sub-pixel rendering issues with two approaches:

- Replaces the approximate circle size with trig precision.
- Adds flat sides to the dot connectors so they overlap with the dots.
- Groups the shapes by colors so that opacity can be applied on the group level. This required some refactoring of color/opacity.